### PR TITLE
Add explicit headers for CUDA12 support

### DIFF
--- a/submodules/diff-gaussian-rasterization/cuda_rasterizer/rasterizer_impl.h
+++ b/submodules/diff-gaussian-rasterization/cuda_rasterizer/rasterizer_impl.h
@@ -8,6 +8,7 @@
  *
  * For inquiries contact  george.drettakis@inria.fr
  */
+ // Copyright (c) 2024-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 
 #pragma once
 
@@ -15,6 +16,7 @@
 #include <vector>
 #include "rasterizer.h"
 #include <cuda_runtime_api.h>
+#include <cstdint>
 
 namespace CudaRasterizer
 {

--- a/submodules/gaussian-rasterization-grad/cuda_rasterizer/rasterizer_impl.h
+++ b/submodules/gaussian-rasterization-grad/cuda_rasterizer/rasterizer_impl.h
@@ -16,6 +16,7 @@
 #include <vector>
 #include "rasterizer.h"
 #include <cuda_runtime_api.h>
+#include <cstdint>
 
 namespace CudaRasterizer
 {

--- a/submodules/simple-knn/simple_knn.cu
+++ b/submodules/simple-knn/simple_knn.cu
@@ -9,11 +9,17 @@
  * For inquiries contact  george.drettakis@inria.fr
  */
 
+/* Copyright (c) 2024-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved. */
+
+
 #define BOX_SIZE 1024
+
+#include <float.h>
 
 #include "cuda_runtime.h"
 #include "device_launch_parameters.h"
 #include "simple_knn.h"
+#include <cfloat>
 #include <cub/cub.cuh>
 #include <cub/device/device_radix_sort.cuh>
 #include <vector>


### PR DESCRIPTION
Following [this issue](https://github.com/graphdeco-inria/gaussian-splatting/issues/923), adding explicit headers to some CUDA rasterizer functions to enable building with CUDA 12+.