### PR TITLE
support for logging images with loss heatmap to wandb

### DIFF
--- a/arguments/__init__.py
+++ b/arguments/__init__.py
@@ -133,6 +133,11 @@ class ModelParams(ParamGroup):
         self.wandb_log_images = False
         self.wandb_tags = ""
         self.wandb_log_interval = 10
+        self.wandb_log_error_maps = True
+        self.wandb_log_error_map_frames = 2
+        self.wandb_error_map_vmin = 0.0
+        self.wandb_error_map_vmax = 0.3
+        self.wandb_error_map_cmap = "jet"
 
         self.flow_model_ckpt = 'unimatch/pretrained/gmflow-scale1-mixdata-train320x576-4c3a6e9a.pth'
         # self.depth_model_ckpt = 'unimatch/pretrained/gmdepth-scale1-regrefine1-resumeflowthings-scannet-90325722.pth'

--- a/configs/dynerf.yaml
+++ b/configs/dynerf.yaml
@@ -33,8 +33,13 @@ model_params:
     depth_until_iter: 10000
 
     # fill these in for your wandb logging
-    # wandb_project: 
-    # wandb_entity: 
+    wandb_project: ''
+    wandb_entity: ''
+    wandb_log_error_maps: True
+    wandb_log_error_map_frames: 300 # log error maps for all 300 frames in dynerf sequences
+    wandb_error_map_vmin: 0.0
+    wandb_error_map_vmax: 0.4 # all errors above 0.4 are clamped to red
+    wandb_error_map_cmap: "jet"
     wandb_tags: 'default'
     use_wandb: False
 


### PR DESCRIPTION
This MR enables better visualization of training logs, by logging a comparison image between ground truth, rendered, and loss heatmap for the validation and test views during training. This image is logged at the end of training each frame. The sample [configs/dynerf.yaml](https://github.com/NVlabs/queen/blob/main/configs/dynerf.yaml) file has been updated to demonstrate how to enable this logging. 

<img width="897" height="290" alt="wandb screenshot" src="https://github.com/user-attachments/assets/ebe3a823-f804-4722-b376-05242d52ca81" />
